### PR TITLE
Promise chaining bug-fix. closes #1

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -19,10 +19,9 @@ function loadExisting(id) {
             createTable(game.size);
             document.getElementById("level").value = game.level;
         })
-        .then(
-            fetch(cellsUrl)
-            .then((res) => res.json())
-            .then((updates) => updates.forEach(onUpdate)));
+        .then(()=>fetch(cellsUrl))
+        .then((res) => res.json())
+        .then((updates) => updates.forEach(onUpdate));
 }
 
 function startNew(level) {


### PR DESCRIPTION
![18788310_1468972913192659_1927349071_n](https://cloud.githubusercontent.com/assets/12658571/26553454/c41550f2-449c-11e7-8990-087144ec4c83.png)

![18767164_1468973606525923_560190013_o](https://cloud.githubusercontent.com/assets/12658571/26553467/d14b6fd6-449c-11e7-8e63-07c8fd75b971.png)


The problem was incorrect chaining of promises and because of that, sometimes, 'fetching cellsUrl' was faster than 'fetching gameUrl'.